### PR TITLE
added optional webpack define for graphqlUrl

### DIFF
--- a/src/configRc.ts
+++ b/src/configRc.ts
@@ -47,6 +47,7 @@ export default class ConfigRc {
     options.frontendBuildDir = options.frontendBuildDir || 'build/client';
     options.dllBuildDir = options.dllBuildDir || 'build/dll';
     options.backendUrl = options.backendUrl || 'http://localhost:8080';
+    options.graphqlUrl = options.graphqlUrl || options.backendUrl;
     options.webpackDll = options.webpackDll !== undefined ? options.webpackDll : true;
   }
 }

--- a/src/plugins/WebpackPlugin.ts
+++ b/src/plugins/WebpackPlugin.ts
@@ -14,7 +14,7 @@ const __WINDOWS__ = /^win/.test(process.platform);
 const createPlugins = (builder: Builder, spin: Spin) => {
   const stack = builder.stack;
   const webpack = requireModule('webpack');
-  const buildNodeEnv = spin.dev ? (spin.test ? 'test' : 'development') : 'production';
+  const buildNodeEnv = process.env.NODE_ENV || (spin.dev ? (spin.test ? 'test' : 'development') : 'production');
 
   let plugins = [];
 

--- a/src/plugins/WebpackPlugin.ts
+++ b/src/plugins/WebpackPlugin.ts
@@ -43,6 +43,7 @@ const createPlugins = (builder: Builder, spin: Spin) => {
   }
 
   const backendUrl = spin.options.backendUrl.replace('{ip}', ip.address());
+  const graphqlUrl = spin.options.graphqlUrl.replace('{ip}', ip.address());
 
   if (stack.hasAny('dll')) {
     const name = `vendor_${builder.parent.name}`;
@@ -71,6 +72,7 @@ const createPlugins = (builder: Builder, spin: Spin) => {
           __DEV__: spin.dev,
           'process.env.NODE_ENV': `"${buildNodeEnv}"`,
           __BACKEND_URL__: `"${backendUrl}"`,
+          __GRAPHQL_URL__: `"${graphqlUrl}"`,
           ...spin.options.defines
         })
       ]);
@@ -83,6 +85,7 @@ const createPlugins = (builder: Builder, spin: Spin) => {
           __DEV__: spin.dev,
           'process.env.NODE_ENV': `"${buildNodeEnv}"`,
           __BACKEND_URL__: `"${backendUrl}"`,
+          __GRAPHQL_URL__: `"${graphqlUrl}"`,
           ...spin.options.defines
         })
       ]);

--- a/src/plugins/WebpackPlugin.ts
+++ b/src/plugins/WebpackPlugin.ts
@@ -14,7 +14,7 @@ const __WINDOWS__ = /^win/.test(process.platform);
 const createPlugins = (builder: Builder, spin: Spin) => {
   const stack = builder.stack;
   const webpack = requireModule('webpack');
-  const buildNodeEnv = process.env.NODE_ENV || (spin.dev ? (spin.test ? 'test' : 'development') : 'production');
+  const buildNodeEnv = spin.dev ? (spin.test ? 'test' : 'development') : 'production';
 
   let plugins = [];
 


### PR DESCRIPTION
If you have `SSR` enabled and wanted to run `graphql` server seperately, it would be better we define `__GRAPHQL_URL__` for the client server to connect to the graphql server. 