### PR TITLE
place correct node environment

### DIFF
--- a/src/plugins/WebpackPlugin.ts
+++ b/src/plugins/WebpackPlugin.ts
@@ -14,7 +14,7 @@ const __WINDOWS__ = /^win/.test(process.platform);
 const createPlugins = (builder: Builder, spin: Spin) => {
   const stack = builder.stack;
   const webpack = requireModule('webpack');
-  const buildNodeEnv = spin.dev ? (spin.test ? 'test' : 'development') : 'production';
+  const buildNodeEnv = process.env.NODE_ENV || (spin.dev ? (spin.test ? 'test' : 'development') : 'production');
 
   let plugins = [];
 


### PR DESCRIPTION
If we still want to run `spin watch` in different environment such as `staging` so we are not hard coding the `process.envNODE_ENV`